### PR TITLE
Updating htslib to work with subset chromosome alignments 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,9 @@ RUN Rscript -e "install.packages('stringr')"
 RUN Rscript -e "source('https://bioconductor.org/biocLite.R'); biocLite('Biostrings')"
 
 # install htslib
-RUN curl -LO https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2 && \
-    tar xfj htslib-1.9.tar.bz2 && \
-    cd htslib-1.9 && \
+RUN curl -LO https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2 && \
+    tar xfj htslib-1.10.2.tar.bz2 && \
+    cd htslib-1.10.2 && \
     autoheader && \
     autoconf && \
     ./configure && \


### PR DESCRIPTION
Issue discovered when using alternative chromosome names (i.e. chr3:70000000-70100000 as chromosome name).