### PR TITLE
Update cluster_identifier version to 1.0.1

### DIFF
--- a/cluster_identifier/src/Makefile
+++ b/cluster_identifier/src/Makefile
@@ -1,10 +1,9 @@
 ## Compilation options/libs
-CC = gcc 
+CC = gcc
 CFLAGS = -Wall -O2
 LIBS = -lz -lpthread -llzma -lbz2 -lcurl -lcrypto -lhts
 
 ## source and exe names
-VERSION = 0.1.0
 SRC = cluster_identifier.c
 BASEMAIN = cluster_identifier
 BUILD_DIR = build

--- a/cluster_identifier/src/cluster_identifier.c
+++ b/cluster_identifier/src/cluster_identifier.c
@@ -15,7 +15,7 @@
 */
 
 #define AUTHOR "Kevin Galens"
-#define VERSION "0.1.1"
+#define VERSION "1.0.1"
 #define PROG "cluster_identifier"
 
 // Holds the settings for this run


### PR DESCRIPTION
Thanks for creating a GitHub release! Right now the version number returned by cluster_identifier is 0.1.1 which does not match the release version on GitHub and breaks Conda package test (https://github.com/bioconda/bioconda-recipes/compare/master...bcbio:scramble-recipe). This will be fixed when you merge this PR and create a new GitHub release v1.0.1.
