### PR TITLE
17 log when no eval argument provided

### DIFF
--- a/cluster_analysis/bin/SCRAMble.R
+++ b/cluster_analysis/bin/SCRAMble.R
@@ -76,6 +76,12 @@ for(i in 1:length(objects)){
 }
 source("usefulFunctions.R")
 ###############################
+## if no eval options provided log and exit
+if(!meis & !deletions){
+    cat('No structural variants to evaluate. Please use flags --eval-meis and --eval-dels to indicate analysis.')
+    stop()
+}
+###############################
 ## READ IN DATA AND PRE-PROCESS
 all = read.delim(clusterFile, as.is=T, header=F,
                  col.names=c("coord", "clipped", "counts", "clipped.consensus", "anchored.consensus"))

--- a/cluster_analysis/bin/make.vcf.R
+++ b/cluster_analysis/bin/make.vcf.R
@@ -40,9 +40,22 @@ make.vcf.header = function(fa, blastRef=None){
 ##############################
 write.scramble.vcf = function(winners, fa, meis=F){
 
+    # return empty fixed data when no variants found
+    if(nrow(winners) == 0){
+        fixed = data.frame('#CHROM' = character(),
+               POS = character(),
+               ID = character(),
+               REF = character(),
+               ALT = character(),
+               QUAL = character(),
+               FILTER = character(),
+               INFO = character(),
+               check.names = F)
+        return(fixed)
+    }
+
   #argument checks
   if (is.null(winners)) return(NULL)
-  if (nrow(winners) == 0) return(NULL)
 
   if(!meis){
     fixed = data.frame('#CHROM' = winners$CONTIG,
@@ -75,18 +88,6 @@ write.scramble.vcf = function(winners, fa, meis=F){
   }   
 
   vcf.cols = c('#CHROM', 'POS', 'ID', 'REF', 'ALT', 'QUAL', 'FILTER', 'INFO')
-  if(nrow(fixed) > 0){
-    return(fixed[,vcf.cols])
-  }else{
-    fixed = data.frame('#CHROM' = character(),
-               POS = character(),
-               ID = character(),
-               REF = character(),
-               ALT = character(),
-               QUAL = character(),
-               FILTER = character(),
-               INFO = character(),
-               check.names = F)
-    return(fixed)
-  }
+  return(fixed[,vcf.cols])
+
 }

--- a/cluster_analysis/bin/make.vcf.R
+++ b/cluster_analysis/bin/make.vcf.R
@@ -12,8 +12,8 @@ get_score = function(right_score, left_score){
 }
 ##############################
 get_refs = function(fa, chrom, start, end){
-  if (missing(fa) | missing(chrom) | missing(start) | missing(end)) return(NULL)
-  if (! chrom %in% names(fa)) return(NULL)
+  if (missing(fa) | missing(chrom) | missing(start) | missing(end)) return('N')
+  if (! chrom %in% names(fa)) return('N')
   fa = fa[chrom]
   seq = subseq(fa, start=start, end=end)
   return(as.vector(seq))


### PR DESCRIPTION
1. log and exit when no `eval` arguments provided
2. return valid VCF when no variants identified
3. return valid VCF when ref/alt cannot be obtained from fasta